### PR TITLE
Configurable logging

### DIFF
--- a/config.js
+++ b/config.js
@@ -9,6 +9,21 @@ module.exports = {
     /* Web UI */
     webServer: 8080,
 
+    /*Log Levels - default is "info"
+     *  
+     *  This setting controls all logging into
+     *  the server.log file - other than the
+     *  restart message which will ALWAYS show.
+     *
+     * "info" -> log info and error events
+     * "error" -> log error events only
+     * "silent" -> do not log at all
+     *
+     * debug, warn, fatal, error, http could be 
+     * implemented as well, but not done yet*/
+    logLevel: "info",
+    
+    /* SSL configurations */
     ssl: {
         port: 5567,
         options: {

--- a/server.js
+++ b/server.js
@@ -42,18 +42,22 @@ Server.prototype.start = function() {
     console.log('========================');
     console.log('Janus VR Presence Server')
     console.log('========================');
-    console.log('Listening on port ' + config.port);
-    log.info('Starting socket server...');
+    log.info('Startup date/time: ' + Date());
+
+    console.log('See server.log for activity information and config.js for configuration');
+    console.log('Log level: ' + config.logLevel);
+    console.log('Startup date/time: ' + Date());
 
     this.server = net.createServer(this.onConnect.bind(this));
     this.server.listen(config.port, function(err){
 
         if(err) {
-            log.error('Error listening on port');
+            log.error('Socket Server error listening on port: ' + config.port);
             process.exit(1);
         }
 
-        log.info('Server listening');
+        log.info('Socket Server listening on port: ' + config.port);
+        console.log('Socket Server listening on port: ' + config.port);
 
     });
 
@@ -63,11 +67,11 @@ Server.prototype.start = function() {
         this.ssl.listen(config.ssl.port, function(err){
 
             if(err) {
-                log.error('Error listening on port');
+                log.error('SSL Server error listening on port: ' + config.ssl.port);
                 process.exit(1);
             }
 
-            log.info('Server listening (SSL)');
+            log.info('SSL Server listening on port: ' + config.ssl.port);
 
         });
     }
@@ -98,10 +102,8 @@ Server.prototype.startWebServer = function() {
     this.ws.use(router);
 
     this.ws.listen(config.webServer);
-    log.info('Webserver started on port: ' + config.webServer);
-    
-    console.log('Start Date/Time: ' + Date());
-    console.log('See server.log for activity information');
+    log.info('Web Server listening on port: ' + config.webServer);
+
 };
 
 Server.prototype.onConnect = function(socket) {

--- a/src/Logging.js
+++ b/src/Logging.js
@@ -1,73 +1,86 @@
-
 var npmlog = require('npmlog');
-var args = require('optimist').argv;
+var args = require('optimist').argv;//Noted that this is deprecated.  TODO: replace with either minimist or yargs
 var onFinished = require('finished');
 var fs = require('fs');
+var config = require(args.config || '../config.js');
 
 var rootDirectory = __dirname.substr(0,__dirname.lastIndexOf('/')+1);
 
 function callingFile(index, err) {
 
-	var old = Error.prepareStackTrace;
+    var old = Error.prepareStackTrace;
 
-	Error.prepareStackTrace = function (_, stack) {
-		return stack;
-	};
+    Error.prepareStackTrace = function (_, stack) {
+        return stack;
+    };
 
-	if(err === undefined) {
-		err = {};
-		Error.captureStackTrace(err);
-	}
-	callFrame = err.stack[index];
+    if(err === undefined) {
+        err = {};
+        Error.captureStackTrace(err);
+    }
+    callFrame = err.stack[index];
 
-	Error.prepareStackTrace = old;
-	return callFrame.getFileName().replace(rootDirectory,'') + ':' + callFrame.getLineNumber();
+    Error.prepareStackTrace = old;
+    return callFrame.getFileName().replace(rootDirectory,'') + ':' + callFrame.getLineNumber();
 }
 
 
 if(args.debug) {
-	npmlog.enableColor();
+    npmlog.enableColor();
 } else {
-	npmlog.stream = fs.createWriteStream('server.log', {'flags':'a'});
-	npmlog.stream.write('------------- Restart -----------------');
+    npmlog.stream = fs.createWriteStream('server.log', {'flags':'a'});
+    npmlog.stream.write('------------- Restart -----------------\n');
+    switch (config.logLevel){
+        case 'info':
+            npmlog.level = 'info';
+            break;
+        case 'error':
+            npmlog.level = 'error';
+            break;
+        case 'silent':
+            npmlog.level = 'silent';
+            break;
+        default:
+            npmlog.level = 'info';
+    }
 }
 
 function ts() {
-	return new Date().toTimeString().substring(0,8);
+    return new Date().toTimeString().substring(0,8);
 }
 
 function log(level) {
-	if(level==='debug' && !args.debug) {
-		return;
-	}
+    if(level==='debug' && !args.debug) {
+        return;
+    }
 
-	var msg = Array.prototype.slice.call(arguments,1);
-	npmlog.log.apply(npmlog, [level, ts()+' '+callingFile(2)].concat(msg));
+    var msg = Array.prototype.slice.call(arguments,1);
+    npmlog.log.apply(npmlog, [level, ts()+' '+callingFile(2)].concat(msg));
 }
 
 process.on('uncaughtException', function(ex){
-	npmlog.log('error', ts()+' '+callingFile(0,ex), "Uncaught exception %s", ex.message);
-	setTimeout(function(){ process.exit(1); },10);
+    npmlog.log('error', ts()+' '+callingFile(0,ex), "Uncaught exception %s", ex.message);
+    setTimeout(function(){ process.exit(1); },10);
 });
 
-
 function httpLog(req,res,next) {
-	var start = process.hrtime();
+    var start = process.hrtime();
 
-	onFinished(res, function(){
-		var time = process.hrtime(start);
-		time = (time[0] * 1e3) + (time[1]/1e6);
-		npmlog.log('http', req.path, '%d time: %d ms', res.statusCode, time);
-	});
-	next();
+    onFinished(res, function(){
+        var time = process.hrtime(start);
+        time = (time[0] * 1e3) + (time[1]/1e6);
+        npmlog.log('http', req.path, '%d time: %d ms', res.statusCode, time);
+    });
+    next();
 }
 
+
 module.exports = {
-	_log: npmlog,
-	info: log.bind(null,'info'),
-	debug: log.bind(null,'verbose'),
-	warn: log.bind(null,'warn'),
-	fatal: log.bind(null,'fatal'),
-	error: log.bind(null,'error'),
-	http: httpLog
+    _log: npmlog,
+    info: log.bind(null,'info'),
+    debug: log.bind(null,'verbose'),
+    warn: log.bind(null,'warn'),
+    fatal: log.bind(null,'fatal'),
+    error: log.bind(null,'error'),
+    http: httpLog
 };


### PR DESCRIPTION
Related to #11 

Logging is now configurable in the config.js file.  There are 3 settings (info, error and silent).  I've given it a few goes on my machine and this seems to work fine.  However. I have not done extensive testing.

```
 /*Log Levels - default is "info"
     *
     *  This setting controls all logging into
     *  the server.log file - other than the
     *  restart message which will ALWAYS show.
     *
     * "info" -> log info and error events
     * "error" -> log error events only
     * "silent" -> do not log at all
     *
     * debug, warn, fatal, error, http could be
     * implemented as well, but not done yet*/
    logLevel: "info",
```

Note that I tidied up the spacing in the Logging.js file as well as it was using double tabs rather than 4 x spaces like in other files.  Just wanted to mention this in case the number of lines changed is a little alarming for a minor change

Feedback welcome!
