### PR TITLE
Added real examples from JanusVR 40.3

### DIFF
--- a/API Documentation.md
+++ b/API Documentation.md
@@ -24,15 +24,25 @@ Copy and paste the examples below to see how it works
 #### 1.1 "logon" Method
 -----------------------
 
-Client -> Server Message Example:
+Client -> Server Message Example
+```json
+{"method":"logon","data":{"userId":"LL", "version":"23.4","roomId":"345678354764987457"}}
+```
 
-> {"method":"logon","data":{"userId":"LL", "version":"23.4","roomId":"345678354764987457"}}
+
+Real example from JanusVR 40.3
+
+```json
+{"method":"logon","data":{"userId":"ProudMinna333","version":"40.3","roomId":"e562b2e1339fc08d635d28481121857c"}}
+```
 
 Server -> Client Response Example:
 
 Will receive: 
 
-> {"method":"okay"} if everything was okay or a {"method":"error", "data":{"message": "Some error string"}}
+```json
+{"method":"okay"} if everything was okay or a {"method":"error", "data":{"message": "Some error string"}}
+```
 
 You need to do this before anything else.  roomId is the room you are starting in and you will be subscribed to that room's events.  Version is the client version and roomId is a MD5 hash of the room's URL. Logon will fail if a client is already using that name 
 
@@ -45,7 +55,15 @@ TODO: Reject incompatable clients
 
 When you pass through a portal:
 
-> {"method":"enter_room", "data": { "roomId": "345678354764987457" }}
+```json
+{"method":"enter_room", "data": { "roomId": "345678354764987457" }}
+```
+
+Real example from JanusVR 40.3:
+
+```json
+{"method":"enter_room", "data": {"roomId":"e562b2e1339fc08d635d28481121857c"}}
+```
 
 ----------------------
 #### 1.3 "move" Method
@@ -53,9 +71,25 @@ When you pass through a portal:
 
 When the user position has moved:
 
-> {"method":"move", "data": [0,0,0,0,0,0,0] }
+```json
+{"method":"move", "data": [0,0,0,0,0,0,0] }
+```
 
 Data can be anything you like, it will be passed to observers without validation
+
+Real example from JanusVR 40.3:
+
+JanusVR submits extra information in first move call and every so often after the first call.  This is an example of a move call with extra information:
+
+```json
+{"method":"move", "data":{"pos":"8.38889 -0.267704 -5.83333","dir":"-1 -1.33e-06 9.42e-07","view_dir":"-1 -1.33e-06 9.42e-07","up_dir":"-1.33e-06 1 1.25e-12","head_pos":"0 0 0","avatar":"<FireBoxRoom><Assets><AssetObject id=^head^ src=^http://avatars.vrsites.com/chibii/head_male.obj^ mtl=^http://avatars.vrsites.com/chibii/mtls/head_male3.mtl^ /><AssetObject id=^body^ src=^http://avatars.vrsites.com/chibii/body_male.obj^ mtl=^http://avatars.vrsites.com/chibii/mtls/body_male3.mtl^ /></Assets><Room><Ghost id=^ProudMinna333^ js_id=^3^ scale=^1.700000 1.700000 1.700000^ head_id=^head^ head_pos=^0.000000 0.750000 0.000000^ body_id=^body^ /></Room></FireBoxRoom>"}}
+```
+
+Most JanusVR calls only provide a limited data set:
+
+```json
+{"method":"move", "data":{"pos":"8.38889 -0.267704 -5.83333","dir":"-1 -1.33e-06 9.42e-07","view_dir":"-1 -1.33e-06 9.42e-07","up_dir":"-1.33e-06 1 1.25e-12","head_pos":"0 0 0"}}
+```
 
 -----------------------
 #### 1.4 "chat" Method
@@ -63,9 +97,17 @@ Data can be anything you like, it will be passed to observers without validation
 
 When the user wants to send a text message:
 
-> {"method":"chat", "data": "The message"}
+```json
+{"method":"chat", "data": "The message"}
+```
 
 You can pass anything through the data field and it will be sent to all clients subscribed to the current room.
+
+Real example from JanusVR 40.3:
+
+```json
+{"method":"chat", "data": "hello!"}
+```
 
 ----------------------------
 #### 1.5 "subscribe" Method
@@ -73,11 +115,29 @@ You can pass anything through the data field and it will be sent to all clients 
 
 When you wish to start receiving events about a room (you are in that room or looking through a portal)
 
-> {"method":"subscribe", "data": { "roomId": "345678354764987457" }}
+```json
+{"method":"subscribe", "data": { "roomId": "345678354764987457" }}
+```
+
+Real example from JanusVR 40.3:
+
+The first "subscribe" call provides extra information:
+
+```json
+{"method":"subscribe", "data":{"userId":"ProudMinna333","version":"40.3","roomId":"e562b2e1339fc08d635d28481121857c"}}
+```
+
+Subsequent "subscribe" calls provide less information:
+
+```json
+{"method":"subscribe", "data":{"roomId":"69de79e1077103cb59d1a890e96c7ef2"}}
+```
 
 Will receive the following if everything is OK.
 
-> {"method":"okay"}
+```json
+{"method":"okay"}
+```
 
 ------------------------------
 #### 1.6 "unsubscribe" Method
@@ -85,11 +145,19 @@ Will receive the following if everything is OK.
 
 When you no longer wish to receive messages from that room because none of its portals are visible
 
-> {"method":"unsubscribe", "data": { "roomId": "345678354764987457" }}
+```json
+{"method":"unsubscribe", "data": { "roomId": "345678354764987457" }}
+```
+
+Real example from JanusVR 40.3:
+
+> TODO: Grab real example
 
 Will receive the following if everything is OK.
 
-> {"method":"okay"} 
+```json
+{"method":"okay"} 
+```
 
 -------------------------
 #### 1.7 "portal" Method
@@ -97,7 +165,15 @@ Will receive the following if everything is OK.
 
 When a user creates a new portal:
 
-> {"method":"portal", "data":{"url":"http://...", "pos":[1,2,4], "fwd":[0,1,0]}}
+```json
+{"method":"portal", "data":{"url":"http://...", "pos":[1,2,4], "fwd":[0,1,0]}}
+```
+
+Real example from JanusVR 40.3:
+
+```json
+{"method":"portal", "data":{"url":"http://www.vrsites.com","pos":"-7.16883 -0.267702 -6.57243","fwd":"0.967686 0 -0.234104"}}
+```
 
 Will receive the following if everything is OK.
 
@@ -113,7 +189,23 @@ Will receive: {"method":"okay"}
 
 When a user moves in any room that you are subscribed too, will recive notification about your own movement.
 
-> {"method":"user_moved","data":{"roomId":"fgdgd","userId":"LL","position":[0,0,0,0,0,0,0]}}
+```json
+{"method":"user_moved","data":{"roomId":"fgdgd","userId":"LL","position":[0,0,0,0,0,0,0]}}
+```
+
+Real example from interaction with JanusVR 40.3:
+
+Some user_moved notifications will contain extra information:
+
+```json
+{"method":"user_moved","data":{"roomId":"e562b2e1339fc08d635d28481121857c","userId":"ProudMinna333","position":{"pos":"8.38889 -0.267704 -5.83333","dir":"-1 -1.33e-06 9.42e-07","view_dir":"-1 -1.33e-06 9.42e-07","up_dir":"-1.33e-06 1 1.25e-12","head_pos":"0 0 0","avatar":"<FireBoxRoom><Assets><AssetObject id=^head^ src=^http://avatars.vrsites.com/chibii/head_male.obj^ mtl=^http://avatars.vrsites.com/chibii/mtls/head_male3.mtl^ /><AssetObject id=^body^ src=^http://avatars.vrsites.com/chibii/body_male.obj^ mtl=^http://avatars.vrsites.com/chibii/mtls/body_male3.mtl^ /></Assets><Room><Ghost id=^ProudMinna333^ js_id=^3^ scale=^1.700000 1.700000 1.700000^ head_id=^head^ head_pos=^0.000000 0.750000 0.000000^ body_id=^body^ /></Room></FireBoxRoom>"}}}
+```
+
+However, most will only contain something like the following:
+
+```json
+{"method":"user_moved","data":{"roomId":"e562b2e1339fc08d635d28481121857c","userId":"ProudMinna333","position":{"pos":"8.38889 -0.267704 -5.83333","dir":"-1 -1.33e-06 9.42e-07","view_dir":"-1 -1.33e-06 9.42e-07","up_dir":"-1.33e-06 1 1.25e-12","head_pos":"0 0 0"}}}
+```
 
 ----------------------------------
 #### 2.2 "user_chat" notification
@@ -121,7 +213,15 @@ When a user moves in any room that you are subscribed too, will recive notificat
 
 When a user says something in text chat.
 
-> {"method":"user_chat", "data":{"message":"The message", "userId":"LL"}}
+```json
+{"method":"user_chat", "data":{"message":"The message", "userId":"LL"}}
+```
+
+Real example from interaction with JanusVR 40.3:
+
+```json
+{"method":"user_chat", "data":{"roomId":"69de79e1077103cb59d1a890e96c7ef2","userId":"ProudMinna333","message":"hello!"}}
+```
 
 ------------------------------------------------
 #### 2.3 "user_leave"/"user_enter" notification
@@ -129,16 +229,34 @@ When a user says something in text chat.
 
 When a user changes room:
 
-> {"method":"user_leave", "data":{"userId":"LL","roomId":"oldRoomId"}}
+```json
+{"method":"user_leave", "data":{"userId":"LL","roomId":"oldRoomId"}}
+```
 
-> {"method":"user_enter", "data":{"userId":"LL","roomId":"newRoomId"}}
+```json
+{"method":"user_enter", "data":{"userId":"LL","roomId":"newRoomId"}}
+```
 
 The followed up with a move "user_moved" event
+
+Real example from interaction with JanusVR 40.3:
+
+> TODO: Grab example of "user_leave"
+
+> TODO: Grab example of "user_enter"
 
 -----------------------------------
 #### 2.4 "user_portal" notification
 -----------------------------------
 
-When a user creates a portal
+When a user creates a portal:
 
-> {"method":"user_portal", "data":{"userId":"LL","roomId":"345678354764987457","url":"http://...", "pos":[0,0,0], "fwd":[0,1,0]}}
+```json
+{"method":"user_portal", "data":{"userId":"LL","roomId":"345678354764987457","url":"http://...", "pos":[0,0,0], "fwd":[0,1,0]}}
+```
+
+Real example from interaction with JanusVR 40.3:
+
+```json
+{"method":"user_portal", "data":{"roomId":"e562b2e1339fc08d635d28481121857c","userId":"ProudMinna333","url":"http://www.vrsites.com","pos":"-7.16883 -0.267702 -6.57243","fwd":"0.967686 0 -0.234104"}}
+```


### PR DESCRIPTION
Added some real examples to the API documentation to highlight how the interface can be used by a client.  The examples are from JanusVR 40.3.

The examples highlight things which may not be that obvious.  E.g. the "move" method is sometimes used to transfer avatar model information.

This data was grabbed from [debug info](https://gist.github.com/oculushut/fec641be10309f4c20f6) I generated locally.

This kind of information should help anybody who wants to implement special features for particular servers... e.g. if you intercepted the avatar information you could force users to appear in a particular way.  If you intercept movement information you could implement server specific detail (e.g. earth quakes where user is moved around or wind which could push users left or right... etc).  Or maybe bring all users to a particular point in a room so they can witness an event etc.